### PR TITLE
Prefer pip over easy_install

### DIFF
--- a/prestodb/centos6-oj8-openldap/Dockerfile
+++ b/prestodb/centos6-oj8-openldap/Dockerfile
@@ -73,6 +73,6 @@ RUN keytool -import -alias caroot -storepass testldap -keystore /etc/openldap/ce
     -file /etc/openldap/certs/caroot.cer
 
 # Install supervisor.d
-RUN yum install -y python-setuptools && easy_install supervisor
+RUN yum install -y python-setuptools epel-release && yum install -y python-pip && pip install supervisor
 
 CMD supervisord -c /etc/supervisord.conf

--- a/prestodb/hdp2.5-base/Dockerfile
+++ b/prestodb/hdp2.5-base/Dockerfile
@@ -35,7 +35,7 @@ RUN \
     hive-metastore \
     hive-server2 \
 
-  && yum install -y python-setuptools && easy_install supervisor \
+  && yum install -y python-setuptools epel-release && yum install -y python-pip && pip install supervisor \
 
   && yum -y clean all && rm -rf /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Prefer pip over easy_install

pip is newer and more robust than easy_install and so it is recommended
to use pip.

See https://packaging.python.org/discussions/pip-vs-easy-install/
