### PR TITLE
Add simple tests for docker clusters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_install:
 
 install: make
 
+script: make test
+
 before_deploy:
   # decrypt the github deploy key
   - openssl aes-256-cbc -K $encrypted_cd2beb64619c_key -iv $encrypted_cd2beb64619c_iv

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ LABEL_PARENT_SH=bin/label-parent.sh
 DEPEND_SH=bin/depend.sh
 FLAG_SH=bin/flag.sh
 PUSH_SH=bin/push.sh
+TEST_SH=bin/test.sh
 BUILDDIR=build
 DEPDIR=$(BUILDDIR)/depends
 FLAGDIR=$(BUILDDIR)/flags
@@ -258,6 +259,10 @@ $(GVWHOLE): $(GVFRAGS) Makefile
 $(GVFRAGS): $(GVDIR)/%.gv.frag: %/Dockerfile $(DEPEND_SH)
 	-mkdir -p $(dir $@)
 	$(SHELL) $(DEPEND_SH) -g $< $(call docker-tag,$(UNLABELLED_TAGS)) >$@
+
+.PHONY: test
+test: 
+	$(TEST_SH) hdp2.5-hive
 
 .PHONY: clean 
 clean:

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -e
+
+function retry() {
+  END=$(($(date +%s) + 600))
+
+  while (( $(date +%s) < $END )); do
+    set +e
+    "$@"
+    EXIT_CODE=$?
+    set -e
+
+    if [[ ${EXIT_CODE} == 0 ]]; then
+      break
+    fi
+    sleep 5
+  done
+
+  return ${EXIT_CODE}
+}
+
+function environment_compose() {
+  docker-compose -f "${DOCKER_CONF_LOCATION}/${ENVIRONMENT}/docker-compose.yml" "$@"
+}
+
+function run_in_hadoop_master_container() {
+  environment_compose exec hadoop-master "$@"
+}
+
+function check_hadoop() {
+  run_in_hadoop_master_container su hive -c "hive -e 'select 1;'" > /dev/null 2>&1
+}
+
+function run_tests() {
+  run_in_hadoop_master_container su hive -c "hive -e 'SELECT 1'"
+  run_in_hadoop_master_container su hive -c "hive -e 'CREATE TABLE foo (a INT);'"
+  run_in_hadoop_master_container su hive -c "hive -e 'INSERT INTO foo VALUES (54);'"
+  # SELECT with WHERE to make sure that map-reduce job is scheduled
+  run_in_hadoop_master_container su hive -c "hive -e 'SELECT a FROM foo WHERE a > 0;'"
+}
+
+function stop_all_containers() {
+  local ENVIRONMENT
+  for ENVIRONMENT in $(getAvailableEnvironments)
+  do
+     stop_docker_compose_containers ${ENVIRONMENT}
+  done
+}
+
+function stop_docker_compose_containers() {
+  local ENVIRONMENT=$1
+  RUNNING_CONTAINERS=$(environment_compose ps -q)
+
+  if [[ ! -z ${RUNNING_CONTAINERS} ]]; then
+    # stop containers started with "up", removing their volumes
+    # Some containers (SQL Server) fail to stop on Travis after running the tests. We don't have an easy way to
+    # reproduce this locally. Since all the tests complete successfully, we ignore this failure.
+    environment_compose down -v || true
+  fi
+
+  echo "Docker compose containers stopped: [$ENVIRONMENT]"
+}
+
+function cleanup() {
+  stop_docker_compose_containers ${ENVIRONMENT}
+
+  # Ensure that the logs processes are terminated.
+  # In most cases after the docker containers are stopped, logs processes must be terminated.
+  if [[ ! -z ${LOGS_PID} ]]; then
+    kill ${LOGS_PID} 2>/dev/null || true
+  fi
+
+  # docker logs processes are being terminated as soon as docker container are stopped
+  # wait for docker logs termination
+  wait 2>/dev/null || true
+}
+
+function terminate() {
+  trap - INT TERM EXIT
+  set +e
+  cleanup
+  exit 130
+}
+
+function getAvailableEnvironments() {
+  for i in $(ls -d $DOCKER_CONF_LOCATION/*/); do echo ${i%%/}; done \
+     | grep -v files | grep -v common | xargs -n1 basename
+}
+
+SCRIPT_DIR=${BASH_SOURCE%/*}
+PROJECT_ROOT="${SCRIPT_DIR}/.."
+DOCKER_CONF_LOCATION="${PROJECT_ROOT}/etc/compose"
+
+ENVIRONMENT=$1
+
+# Get the list of valid environments
+if [[ ! -f "$DOCKER_CONF_LOCATION/$ENVIRONMENT/docker-compose.yml" ]]; then
+   echo "Usage: run_on_docker.sh <`getAvailableEnvironments | tr '\n' '|'`>"
+   exit 1
+fi
+
+shift 1
+
+# check docker and docker compose installation
+docker-compose version
+docker version
+
+stop_all_containers
+
+# catch terminate signals
+trap terminate INT TERM EXIT
+
+environment_compose up -d 
+
+# start docker logs for the external services
+environment_compose logs --no-color -f &
+
+LOGS_PID=$!
+
+# wait until hadoop processes is started
+retry check_hadoop
+
+# run tests
+set +e
+sleep 10
+run_tests
+EXIT_CODE=$?
+set -e
+
+# execution finished successfully
+# disable trap, run cleanup manually
+trap - INT TERM EXIT
+cleanup
+
+exit ${EXIT_CODE}

--- a/etc/compose/hdp2.5-hive/docker-compose.yml
+++ b/etc/compose/hdp2.5-hive/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2.0'
+services:
+  hadoop-master:
+    hostname: hadoop-master
+    image: prestodb/hdp2.5-hive:latest
+


### PR DESCRIPTION
Add simple tests for docker clusters

This setups the HDP cluster and make sure that it is possible to insert
or select data with Hive with usage of map-reduce jobs.

So far HDP is only tested as this image the most mature.
Support for other images will be added later.
