### PR TITLE
Fix typo in krb5-workstation rpm name

### DIFF
--- a/prestodb/hdp2.6-hive-kerberized/Dockerfile
+++ b/prestodb/hdp2.6-hive-kerberized/Dockerfile
@@ -14,7 +14,7 @@ FROM prestodb/hdp2.6-hive:unlabelled
 MAINTAINER Presto community <https://prestodb.io/community.html>
 
 # INSTALL KERBEROS
-RUN yum install -y krb5-libs krb5-server krb5-worqkstation \
+RUN yum install -y krb5-libs krb5-server krb5-workstation \
   && yum -y clean all && rm -rf /tmp/* /var/tmp/*
 
 # COPY CONFIGURATION


### PR DESCRIPTION
Fix typo in krb5-workstation rpm name
