### PR TITLE
Increase Java Heap size for CDH to 512M

### DIFF
--- a/prestodb/cdh5.13-hive/files/etc/hadoop/conf/hadoop-env.sh
+++ b/prestodb/cdh5.13-hive/files/etc/hadoop/conf/hadoop-env.sh
@@ -20,7 +20,7 @@
 # export HADOOP_MAPRED_HOME=/usr/lib/hadoop-mapreduce
 
 # The maximum amount of heap to use, in MB. Default is 1000.
-export HADOOP_HEAPSIZE=256
+export HADOOP_HEAPSIZE=512
 
 # Extra Java runtime options.  Empty by default.
 export HADOOP_NAMENODE_OPTS="$HADOOP_NAMENODE_OPTS -Xmx512m"


### PR DESCRIPTION
Needed by newer distro which sometimes trips over if this is lower.

Tried setting this via /etc/hive/conf/hive-env.sh so it affects hiveserver2 only, but setting it there has no effect.