### PR TITLE
Remove docker update on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ branches:
 services: 
   - docker
 
-before_install: 
-  - sudo apt-get install dc
-
 install: make ${IMAGE_TO_BUILD}
 
 script: make test IMAGE_TO_TEST=${IMAGE_TO_TEST}

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,6 @@ services:
 
 before_install: 
   - sudo apt-get install dc
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y install docker-ce
-  - docker --version
 
 install: make ${IMAGE_TO_BUILD}
 

--- a/bin/depend.sh
+++ b/bin/depend.sh
@@ -132,7 +132,7 @@ while getopts ":dgp:x" c; do
 	esac
 done
 
-shift "$(dc -e"$OPTIND 1 - p")"
+shift $((OPTIND-1))
 
 if [ -z "$own_image_function" ] || [ $# -lt 2 ]; then
 	usage


### PR DESCRIPTION
Let's use the docker version pre-installed by Travis.

Docker update was added in
https://github.com/Teradata/docker-images/pull/37 and I couldn't track
the reason. Perhaps, the reason is obsolete by now anyway.