### PR TITLE
Set JAVA_HOME the same way in images

### DIFF
--- a/prestodb/centos6-oj8-openldap/Dockerfile
+++ b/prestodb/centos6-oj8-openldap/Dockerfile
@@ -18,7 +18,9 @@ ARG JDK_PATH
 ENV JAVA_HOME=$JDK_PATH
 
 # INSTALL OPENLDAP
-RUN yum -y install openldap openldap-clients openldap-servers
+RUN yum -y install openldap openldap-clients openldap-servers \
+    # Cleanup
+    && yum -y clean all && rm -rf /tmp/* /var/tmp/*
 
 # COPY CONFIGURATION
 COPY ./files /

--- a/prestodb/centos6-oj8/Dockerfile
+++ b/prestodb/centos6-oj8/Dockerfile
@@ -57,4 +57,4 @@ RUN \
     # cleanup
     yum -y clean all && rm -rf /tmp/* /var/tmp/*
 
-ENV JAVA_HOME $JDK_PATH/jre/
+ENV JAVA_HOME $JDK_PATH


### PR DESCRIPTION
centos6-oj8 was setting JAVA_HOME to jdk-path/jre
centos6-oj8-openldap was setting JAVA_HOME to jdk-path

This commit makes them compatible, always use the same.