### PR TITLE
Update hdp to 2.6.5 and fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ DEPS := $(foreach dockerfile,$(DOCKERFILES),$(DEPDIR)/$(dockerfile:/Dockerfile=.
 FLAGS := $(foreach dockerfile,$(DOCKERFILES),$(FLAGDIR)/$(dockerfile:/Dockerfile=.flags))
 
 RELEASE_TAGS := $(VERSION_TAGS) $(GIT_HASH_TAGS) $(LATEST_TAGS)
-SNAPSHOT_TAGS := $(GIT_HASH_TAGS) $(LATEST_TAGS)
+SNAPSHOT_TAGS := $(GIT_HASH_TAGS)
 
 #
 # Make a list of the Docker images we depend on, but aren't built from

--- a/prestodb/hdp2.6-hive/Dockerfile
+++ b/prestodb/hdp2.6-hive/Dockerfile
@@ -17,7 +17,7 @@ MAINTAINER Presto community <https://prestodb.io/community.html>
 RUN ln -snf "/usr/share/zoneinfo/Asia/Kathmandu" /etc/localtime && echo "Asia/Kathmandu" > /etc/timezone
 
 # Install HDP repo
-RUN wget -nv http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.3.0/hdp.repo -P /etc/yum.repos.d
+RUN wget -nv http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.5.0/hdp.repo -P /etc/yum.repos.d
 
 # Install Hadoop, Hive (w/ MySQL)
 RUN yum install -y \


### PR DESCRIPTION
I think 'make snapshot' should NOT update 'latest' docker tag.
This may cause someone to accidentally download an untested image by mistake.