### PR TITLE
Remove deprecated fs.default.name from configuration

### DIFF
--- a/prestodb/cdh5.12-hive-kerberized/files/etc/hadoop/conf/core-site.xml
+++ b/prestodb/cdh5.12-hive-kerberized/files/etc/hadoop/conf/core-site.xml
@@ -19,11 +19,6 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:8020</value>
-    </property>
-
-    <property>
-        <name>fs.default.name</name>
         <value>hdfs://hadoop-master:9000</value>
     </property>
 

--- a/prestodb/cdh5.12-hive/files/etc/hadoop/conf/core-site.xml
+++ b/prestodb/cdh5.12-hive/files/etc/hadoop/conf/core-site.xml
@@ -19,11 +19,6 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:8020</value>
-    </property>
-
-    <property>
-        <name>fs.default.name</name>
         <value>hdfs://hadoop-master:9000</value>
     </property>
 

--- a/prestodb/cdh5.15-hive-kerberized/files/etc/hadoop/conf/core-site.xml
+++ b/prestodb/cdh5.15-hive-kerberized/files/etc/hadoop/conf/core-site.xml
@@ -19,11 +19,6 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:8020</value>
-    </property>
-
-    <property>
-        <name>fs.default.name</name>
         <value>hdfs://hadoop-master:9000</value>
     </property>
 

--- a/prestodb/cdh5.15-hive/files/etc/hadoop/conf/core-site.xml
+++ b/prestodb/cdh5.15-hive/files/etc/hadoop/conf/core-site.xml
@@ -19,11 +19,6 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:8020</value>
-    </property>
-
-    <property>
-        <name>fs.default.name</name>
         <value>hdfs://hadoop-master:9000</value>
     </property>
 

--- a/prestodb/hdp2.5-hive-kerberized/files/etc/hadoop/conf/core-site.xml
+++ b/prestodb/hdp2.5-hive-kerberized/files/etc/hadoop/conf/core-site.xml
@@ -19,11 +19,6 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:8020</value>
-    </property>
-
-    <property>
-        <name>fs.default.name</name>
         <value>hdfs://hadoop-master:9000</value>
     </property>
 

--- a/prestodb/hdp2.5-hive/files/etc/hadoop/conf/core-site.xml
+++ b/prestodb/hdp2.5-hive/files/etc/hadoop/conf/core-site.xml
@@ -19,11 +19,6 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:8020</value>
-    </property>
-
-    <property>
-        <name>fs.default.name</name>
         <value>hdfs://hadoop-master:9000</value>
     </property>
 

--- a/prestodb/hdp2.6-hive-kerberized/files/etc/hadoop/conf/core-site.xml
+++ b/prestodb/hdp2.6-hive-kerberized/files/etc/hadoop/conf/core-site.xml
@@ -19,11 +19,6 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:8020</value>
-    </property>
-
-    <property>
-        <name>fs.default.name</name>
         <value>hdfs://hadoop-master:9000</value>
     </property>
 

--- a/prestodb/hdp2.6-hive/files/etc/hadoop/conf/core-site.xml
+++ b/prestodb/hdp2.6-hive/files/etc/hadoop/conf/core-site.xml
@@ -19,11 +19,6 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:8020</value>
-    </property>
-
-    <property>
-        <name>fs.default.name</name>
         <value>hdfs://hadoop-master:9000</value>
     </property>
 

--- a/prestodb/iop4.2-hive/files/etc/hadoop/conf/core-site.xml
+++ b/prestodb/iop4.2-hive/files/etc/hadoop/conf/core-site.xml
@@ -19,11 +19,6 @@
 
     <property>
         <name>fs.defaultFS</name>
-        <value>hdfs://hadoop-master:8020</value>
-    </property>
-
-    <property>
-        <name>fs.default.name</name>
         <value>hdfs://hadoop-master:9000</value>
     </property>
 


### PR DESCRIPTION
`fs.default.name` is deprecated, in favor of `fs.defaultFS`.  However,
when both are set, the deprecated one wins (or whichever is salter in
XML file?).  This commits removes the deprecated setting and updates the
value of the one that stays, so that effective `Configuration` remains
the same.