### PR TITLE
Disable anonymous bind in LDAP

### DIFF
--- a/prestodb/centos6-oj8-openldap/Dockerfile
+++ b/prestodb/centos6-oj8-openldap/Dockerfile
@@ -28,6 +28,7 @@ COPY ./files /
 # CONFIGURE OPENLDAP SERVER
 RUN service slapd start && \
     ldapmodify -Y EXTERNAL -H ldapi:/// -f /etc/openldap/setup/modify_server.ldif && \
+    ldapmodify -Y EXTERNAL -H ldapi:/// -f /etc/openldap/setup/ldap_disable_bind_anon.ldif && \
     ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/setup/memberof.ldif && \
     ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/setup/refint.ldif && \
     ldapadd -f /etc/openldap/setup/createOU.ldif -D cn=admin,dc=presto,dc=testldap,dc=com -w admin

--- a/prestodb/centos6-oj8-openldap/files/etc/openldap/setup/ldap_disable_bind_anon.ldif
+++ b/prestodb/centos6-oj8-openldap/files/etc/openldap/setup/ldap_disable_bind_anon.ldif
@@ -1,0 +1,14 @@
+dn: cn=config
+changetype: modify
+add: olcDisallows
+olcDisallows: bind_anon
+
+dn: cn=config
+changetype: modify
+add: olcRequires
+olcRequires: authc
+
+dn: olcDatabase={-1}frontend,cn=config
+changetype: modify
+add: olcRequires
+olcRequires: authc


### PR DESCRIPTION
For many users, enabling anonymous bind is not an option from security
perspective, so we should have it disabled in our tests as well.

Note: supporting no anonymous bind requires changes on Presto side as
well.