### PR TITLE
Memory settings for hive/hms

### DIFF
--- a/prestodb/hdp2.6-hive/files/etc/hive/hive-env.sh
+++ b/prestodb/hdp2.6-hive/files/etc/hive/hive-env.sh
@@ -1,0 +1,1 @@
+export HADOOP_OPTS="$HADOOP_OPTS -Xmx512m"


### PR DESCRIPTION
This is to increase the Xmx for HMS/Hive for this image, since recently I got a lot failures during HIVE_TEST in presto code, Refer:
https://github.com/prestodb/presto/pull/13699
The errors showing in the travis CI are sth like:
com.facebook.presto.spi.PrestoException: hadoop-master:9083: java.net.SocketTimeoutException: Read timed out
	at com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore.getTable(ThriftHiveMetastore.java:292)
	at com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore.getTable(BridgingHiveMetastore.java:83)
	at com.facebook.presto.hive.metastore.CachingHiveMetastore.loadTable(CachingHiveMetastore.java:274)
...


After I did some research inside the containers, in HMS logs, I got stuff like:

Starting Hive Metastore Server
Exception in thread "pool-8-thread-2" java.lang.OutOfMemoryError: GC overhead limit exceeded
WARNING: Use "yarn jar" to launch YARN applications.
Exception in thread "pool-8-thread-364" Exception in thread "pool-8-thread-369" java.lang.OutOfMemoryError: GC overhead limit exceeded
        at org.apache.commons.lang.exception.ExceptionUtils.<clinit>(ExceptionUtils.java:65)
        at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invokeInternal(RetryingHMSHandler.java:203)
        at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invoke(RetryingHMSHandler.java:105)
        at com.sun.proxy.$Proxy16.get_partition(Unknown Source)
        at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Processor$get_partition.getResult(ThriftHiveMetastore.java:10354)
        at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Processor$get_partition.getResult(ThriftHiveMetastore.java:10338)
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
        at org.apache.hadoop.hive.metastore.TUGIBasedProcessor.process(TUGIBasedProcessor.java:103)
        at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Exception in thread "pool-8-thread-365" java.lang.NoCl...

Even I switch to master branch, running this hive tests locally, sometimes I got ok, sometimes I got exactly same errors.