### PR TITLE
Add Apache Hive 3.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - IMAGE_TO_BUILD=prestodb/cdh5.12-hive-kerberized IMAGE_TO_TEST=cdh5.12-hive
   - IMAGE_TO_BUILD=prestodb/cdh5.15-hive-kerberized IMAGE_TO_TEST=cdh5.15-hive
   - IMAGE_TO_BUILD=prestodb/iop4.2-hive IMAGE_TO_TEST=iop4.2-hive
+  - IMAGE_TO_BUILD=prestodb/hive3.1-hive IMAGE_TO_TEST=hive3.1-hive
 
 # Prevent duplicate builds on tag pushes.
 # See https://github.com/mockito/mockito/commit/500519aac4cc13770aa47c1eb7d28e905c27e7aa

--- a/etc/compose/hive3.1-hive/docker-compose.yml
+++ b/etc/compose/hive3.1-hive/docker-compose.yml
@@ -1,0 +1,5 @@
+version: '2.0'
+services:
+  hadoop-master:
+    hostname: hadoop-master
+    image: prestodb/hive3.1-hive:latest

--- a/prestodb/centos7-oj8/Dockerfile
+++ b/prestodb/centos7-oj8/Dockerfile
@@ -1,0 +1,48 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM library/centos:7
+MAINTAINER Presto community <https://prestodb.io/community.html>
+
+COPY ./files /
+
+# Install Java and presto-admin dependences
+RUN \
+    set -xeu && \
+    yum install -y \
+        java-1.8.0-openjdk-devel \
+        nc \
+        wget \
+        && \
+    \
+    # install Zulu JDK (will not be the default `java`)
+    rpm -i https://cdn.azul.com/zulu/bin/zulu11.39.15-ca-jdk11.0.7-linux.x86_64.rpm && \
+    \
+    # install supervisor
+    yum --enablerepo=extras install -y setuptools epel-release && \
+    yum install -y python-pip && \
+    pip install supervisor && \
+    \
+    # install commonly needed packages
+    yum install -y \
+        less `# helpful when troubleshooting product tests` \
+        net-tools `# netstat is required by run_on_docker.sh` \
+        sudo \
+        telnet `# helpful when troubleshooting product tests` \
+        vim `# helpful when troubleshooting product tests` \
+        && \
+    # cleanup
+    yum -y clean all && rm -rf /tmp/* /var/tmp/*
+
+ENV PATH="/usr/local/bin:${PATH}"
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+ENV LANG=en_US.UTF-8

--- a/prestodb/centos7-oj8/files/opt/prestodb/site-override.xslt
+++ b/prestodb/centos7-oj8/files/opt/prestodb/site-override.xslt
@@ -1,0 +1,17 @@
+<!-- Copied from https://stackoverflow.com/a/31186191/65458 and adapted -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" />
+    <xsl:strip-space elements="*" />
+
+    <xsl:variable name="override-properties" select="document($override-path)/configuration/property" />
+
+    <xsl:template match="/configuration">
+        <xsl:copy>
+            <!-- copy local properties not overridden by external properties -->
+            <xsl:copy-of select="property[not(name=$override-properties/name)]" />
+            <!-- add all overriding properties -->
+            <xsl:copy-of select="$override-properties" />
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/prestodb/centos7-oj8/files/usr/local/bin/apply-all-site-xml-overrides
+++ b/prestodb/centos7-oj8/files/usr/local/bin/apply-all-site-xml-overrides
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+  echo "$(basename "$0"): $*" >&2
+  exit 1
+}
+
+if [ $# -ne 1 ]; then
+  fail "Usage: $0 <overrides dir>" >&2
+fi
+
+overrides_dir="$1"
+
+for file in $(find $overrides_dir -name '*.xml'); do
+    target_filename="${file#"$overrides_dir"}"
+    echo "Applying configuration override from $file to $target_filename"
+    apply-site-xml-override "$target_filename" "$file"
+done

--- a/prestodb/centos7-oj8/files/usr/local/bin/apply-site-xml-override
+++ b/prestodb/centos7-oj8/files/usr/local/bin/apply-site-xml-override
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+fail() {
+  echo "$(basename "$0"): $*" >&2
+  exit 1
+}
+
+if [ $# -ne 2 ]; then
+  fail "Usage: $0 <some-site.xml> <overrides.xml>" >&2
+fi
+
+site_xml="$1"
+overrides="$2"
+site_xml_new="$1.new"
+
+test -f "${site_xml}" || fail "${site_xml} does not exist or is not a file"
+test -f "${overrides}" || fail "${overrides} does not exist or is not a file"
+test ! -e "${site_xml_new}" || fail "${site_xml_new} already exists"
+
+xsltproc --param override-path "'${overrides}'" "/opt/prestodb/site-override.xslt" "${site_xml}" > "${site_xml_new}"
+cat "${site_xml_new}" > "${site_xml}" # Preserve file owner & permissions
+rm "${site_xml_new}"

--- a/prestodb/hive3.1-hive/Dockerfile
+++ b/prestodb/hive3.1-hive/Dockerfile
@@ -1,0 +1,70 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM prestodb/centos7-oj8:latest
+MAINTAINER Presto community <https://prestodb.io/community.html>
+
+RUN yum install -y \
+    mariadb-server \
+    openssh \
+    openssh-clients \
+    openssh-server \
+    psmisc \
+    which \
+    && yum -q clean all && rm -rf /var/cache/yum
+
+ARG HADOOP_VERSION=3.1.2
+ARG HIVE_VERSION=3.1.2
+
+# TODO Apache Archive is rate limited -- these should probably go in S3
+ARG HADOOP_BINARY_PATH=https://archive.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz
+ARG HIVE_BINARY_PATH=https://apache.mivzakim.net/hive/hive-$HIVE_VERSION/apache-hive-$HIVE_VERSION-bin.tar.gz
+
+RUN curl -o /tmp/hadoop.tar.gz --url $HADOOP_BINARY_PATH && \
+    tar xzf /tmp/hadoop.tar.gz --directory /opt && mv /opt/hadoop-$HADOOP_VERSION /opt/hadoop
+
+RUN curl -o /tmp/hive.tar.gz --url $HIVE_BINARY_PATH && \
+    tar xzf /tmp/hive.tar.gz --directory /opt && mv /opt/apache-hive-${HIVE_VERSION}-bin /opt/hive
+
+ARG MYSQL_CONNECTOR_VERSION=8.0.13
+ARG AWS_SDK_VERSION=1.11.906
+RUN mkdir /opt/hive/auxlib && \
+    curl -o /opt/hive/auxlib/mysql-connector-java-$MYSQL_CONNECTOR_VERSION.jar https://repo1.maven.org/maven2/mysql/mysql-connector-java/$MYSQL_CONNECTOR_VERSION/mysql-connector-java-$MYSQL_CONNECTOR_VERSION.jar && \
+    curl -o /opt/hive/auxlib/aws-java-sdk-core-$AWS_SDK_VERSION.jar https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-core/$AWS_SDK_VERSION/aws-java-sdk-core-$AWS_SDK_VERSION.jar && \
+    curl -o /opt/hive/auxlib/aws-java-sdk-s3-$AWS_SDK_VERSION.jar https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-s3/$AWS_SDK_VERSION/aws-java-sdk-s3-$AWS_SDK_VERSION.jar
+
+ENV HADOOP_HOME=/opt/hadoop
+ENV HIVE_HOME=/opt/hive
+ENV HADOOP_CLASSPATH=${HADOOP_HOME}/share/hadoop/tools/lib/*
+ENV PATH=${HIVE_HOME}/bin:${HADOOP_HOME}/bin:${PATH}
+
+RUN ssh-keygen -t rsa -b 4096 -C "automation@prestodb.io" -N "" -f /root/.ssh/id_rsa && \
+    ssh-keygen -t rsa -b 4096 -N "" -f /etc/ssh/ssh_host_rsa_key && \
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN chmod 755 /root && chmod 700 /root/.ssh
+RUN passwd --unlock root
+
+# Copy configuration files
+COPY ./files /
+
+# Run setup script
+RUN /root/setup.sh
+
+# HDFS port
+EXPOSE 9000 9870
+
+# HIVE Metastore port
+EXPOSE 9083 10000
+
+EXPOSE 1180
+
+CMD /root/entrypoint.sh

--- a/prestodb/hive3.1-hive/files/etc/hadoop-init.d/init-hdfs.sh
+++ b/prestodb/hive3.1-hive/files/etc/hadoop-init.d/init-hdfs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -x
+
+echo 'N' | hdfs namenode -format
+sed -i -e "s|hdfs://localhost|hdfs://$(hostname)|g" /opt/hadoop/etc/hadoop/core-site.xml
+hdfs namenode &
+sleep 10 && hdfs dfs -mkdir -p /user/hive/warehouse && killall java

--- a/prestodb/hive3.1-hive/files/etc/hadoop-init.d/set-aws-creds.sh
+++ b/prestodb/hive3.1-hive/files/etc/hadoop-init.d/set-aws-creds.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+if [[ -n "${AWS_ACCESS_KEY_ID}" ]]
+then
+    echo "Setting AWS keys"
+    sed -i  -e "s|\"Use AWS_ACCESS_KEY_ID .*\"|${AWS_ACCESS_KEY_ID}|g" \
+            -e "s|\"Use AWS_SECRET_ACCESS_KEY .*\"|${AWS_SECRET_ACCESS_KEY}|g" \
+            /opt/hive/conf/hive-site.xml
+fi

--- a/prestodb/hive3.1-hive/files/etc/supervisord.conf
+++ b/prestodb/hive3.1-hive/files/etc/supervisord.conf
@@ -1,0 +1,21 @@
+[supervisord]
+logfile = /var/log/supervisord.log
+logfile_maxbytes = 50MB
+logfile_backups=10
+loglevel = info
+pidfile = /var/run/supervisord.pid
+nodaemon = true
+directory = /tmp
+strip_ansi = false
+
+[unix_http_server]
+file = /tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl = unix:///tmp/supervisor.sock
+
+[include]
+files = /etc/supervisord.d/*.conf

--- a/prestodb/hive3.1-hive/files/etc/supervisord.d/hdfs-datanode.conf
+++ b/prestodb/hive3.1-hive/files/etc/supervisord.d/hdfs-datanode.conf
@@ -1,0 +1,8 @@
+[program:hdfs-datanode]
+command=hdfs datanode
+startsecs=2
+stopwaitsecs=10
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/hadoop-hdfs/hadoop-hdfs-datanode.log
+autostart=true

--- a/prestodb/hive3.1-hive/files/etc/supervisord.d/hdfs-namenode.conf
+++ b/prestodb/hive3.1-hive/files/etc/supervisord.d/hdfs-namenode.conf
@@ -1,0 +1,8 @@
+[program:hdfs-namenode]
+command=hdfs namenode
+startsecs=2
+stopwaitsecs=10
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/hadoop-hdfs/hadoop-hdfs-namenode.log
+autostart=true

--- a/prestodb/hive3.1-hive/files/etc/supervisord.d/hive-metastore.conf
+++ b/prestodb/hive3.1-hive/files/etc/supervisord.d/hive-metastore.conf
@@ -1,0 +1,9 @@
+[program:hive-metastore]
+# Add `--debug:port=5006` for debugging
+command=hive --service metastore
+startsecs=2
+stopwaitsecs=10
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/hive/hive-metastore.log
+autostart=true

--- a/prestodb/hive3.1-hive/files/etc/supervisord.d/hive-server2.conf
+++ b/prestodb/hive3.1-hive/files/etc/supervisord.d/hive-server2.conf
@@ -1,0 +1,8 @@
+[program:hive-server2]
+command=hive --service hiveserver2
+startsecs=2
+stopwaitsecs=10
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/hive/hive-server2.log
+autostart=true

--- a/prestodb/hive3.1-hive/files/etc/supervisord.d/mysql-metastore.conf
+++ b/prestodb/hive3.1-hive/files/etc/supervisord.d/mysql-metastore.conf
@@ -1,0 +1,8 @@
+[program:mysql-metastore]
+command=/usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/bin/mysqld_safe
+startsecs=2
+stopwaitsecs=10
+user=mysql
+redirect_stderr=true
+stdout_logfile=/var/log/mysql/mysql.log
+autostart=true

--- a/prestodb/hive3.1-hive/files/etc/supervisord.d/socks-proxy.conf
+++ b/prestodb/hive3.1-hive/files/etc/supervisord.d/socks-proxy.conf
@@ -1,0 +1,9 @@
+[program:socks-proxy]
+command=/usr/bin/ssh -o StrictHostKeyChecking=no -v -N -D 0.0.0.0:1180 localhost
+startsecs=2
+stopwaitsecs=10
+startretries=30
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/socks-proxy
+autostart=true

--- a/prestodb/hive3.1-hive/files/etc/supervisord.d/sshd.conf
+++ b/prestodb/hive3.1-hive/files/etc/supervisord.d/sshd.conf
@@ -1,0 +1,9 @@
+[program:sshd]
+command=/usr/sbin/sshd -D
+startsecs=2
+stopwaitsecs=10
+startretries=30
+user=root
+redirect_stderr=true
+stdout_logfile=/var/log/sshd
+autostart=true

--- a/prestodb/hive3.1-hive/files/opt/hadoop/etc/hadoop/core-site.xml
+++ b/prestodb/hive3.1-hive/files/opt/hadoop/etc/hadoop/core-site.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://localhost:9000</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.root.hosts</name>
+        <value>*</value>
+    </property>
+
+    <property>
+        <name>hadoop.proxyuser.root.groups</name>
+        <value>*</value>
+    </property>
+
+</configuration>

--- a/prestodb/hive3.1-hive/files/opt/hadoop/etc/hadoop/hadoop-env.sh
+++ b/prestodb/hive3.1-hive/files/opt/hadoop/etc/hadoop/hadoop-env.sh
@@ -1,0 +1,1 @@
+export HADOOP_HEAPSIZE=256

--- a/prestodb/hive3.1-hive/files/opt/hadoop/etc/hadoop/hdfs-site.xml
+++ b/prestodb/hive3.1-hive/files/opt/hadoop/etc/hadoop/hdfs-site.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+
+<property>
+  <name>dfs.permissions.enabled</name>
+  <value>false</value>
+</property>
+
+</configuration>

--- a/prestodb/hive3.1-hive/files/opt/hive/conf/hive-env.sh
+++ b/prestodb/hive3.1-hive/files/opt/hive/conf/hive-env.sh
@@ -1,0 +1,2 @@
+export HADOOP_CLIENT_OPTS="${HADOOP_CLIENT_OPTS} -Xmx256m -Djava.io.tmpdir=/tmp"
+export HADOOP_HEAPSIZE=256

--- a/prestodb/hive3.1-hive/files/opt/hive/conf/hive-site.xml
+++ b/prestodb/hive3.1-hive/files/opt/hive/conf/hive-site.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+
+    <property>
+        <name>hive.metastore.uris</name>
+        <value>thrift://localhost:9083</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionURL</name>
+        <value>jdbc:mysql://localhost:3306/metastore?useSSL=false</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionDriverName</name>
+        <value>com.mysql.cj.jdbc.Driver</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionUserName</name>
+        <value>root</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionPassword</name>
+        <value>root</value>
+    </property>
+
+    <property>
+        <name>hive.metastore.connect.retries</name>
+        <value>15</value>
+    </property>
+
+    <property>
+        <name>hive.metastore.disallow.incompatible.col.type.changes</name>
+        <value>false</value>
+    </property>
+
+    <property>
+        <!-- https://community.hortonworks.com/content/supportkb/247055/errorjavalangunsupportedoperationexception-storage.html -->
+        <name>metastore.storage.schema.reader.impl</name>
+        <value>org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader</value>
+    </property>
+
+    <property>
+        <name>hive.support.concurrency</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hive.txn.manager</name>
+        <value>org.apache.hadoop.hive.ql.lockmgr.DbTxnManager</value>
+    </property>
+
+    <property>
+        <name>hive.compactor.initiator.on</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hive.compactor.worker.threads</name>
+        <value>1</value>
+    </property>
+
+    <property>
+        <name>fs.s3.awsAccessKeyId</name>
+        <value>"Use AWS_ACCESS_KEY_ID environment variable to set this value"</value>
+    </property>
+
+    <property>
+        <name>fs.s3.awsSecretAccessKey</name>
+        <value>"Use AWS_SECRET_ACCESS_KEY environment variable to set this value"</value>
+    </property>
+
+    <property>
+        <name>fs.s3a.access.key</name>
+        <value>"Use AWS_ACCESS_KEY_ID environment variable to set this value"</value>
+    </property>
+
+    <property>
+        <name>fs.s3a.secret.key</name>
+        <value>"Use AWS_SECRET_ACCESS_KEY environment variable to set this value"</value>
+    </property>
+
+</configuration>

--- a/prestodb/hive3.1-hive/files/root/entrypoint.sh
+++ b/prestodb/hive3.1-hive/files/root/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -x
+
+for init_script in /etc/hadoop-init.d/*; do
+  "${init_script}"
+done
+
+supervisord -c /etc/supervisord.conf

--- a/prestodb/hive3.1-hive/files/root/setup.sh
+++ b/prestodb/hive3.1-hive/files/root/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+ln -s /usr/bin/re solveip /usr/libexec # mariadb-server installs resolveip in /usr/bin but mysql_install_db expects it in /usr/libexec
+mkdir /var/log/mysql /var/log/hive /var/log/hadoop-hdfs
+
+mysql_install_db
+
+chown -R mysql:mysql /var/lib/mysql
+
+/usr/bin/mysqld_safe &
+sleep 10s
+
+echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES;" | mysql
+echo "CREATE DATABASE metastore;" | mysql
+/usr/bin/mysqladmin -u root password 'root'
+/opt/hive/bin/schematool -dbType mysql -initSchema
+
+killall mysqld
+sleep 10s
+chown -R mysql:mysql /var/log/mysql/
+rm -rf /tmp/* /var/tmp/*
+
+adduser hive
+


### PR DESCRIPTION
Cherry pick of https://github.com/trinodb/docker-images/pull/79

Co-authored-by: Guy Cohen <guyc@gett.com>

On top of the original PR from trino, additional changes are made to
1) Run SOCKS proxy 
2) Add "hive.metastore.disallow.incompatible.col.type.changes" set to 'false' in hive-site.xml. This was changed from false to true from Hive versions < 3. It was causing AbstractTestHiveClient#testDropColumn to fail.
3) Added user hive. This is the user we run tests as.