### PR TITLE
Create patch image and add patch workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ on:
 env:
   GIT_CI_USER: ${{ vars.GIT_CI_USER || 'prestodb-ci' }}
   GIT_CI_EMAIL: ${{ vars.GIT_CI_EMAIL || 'ci@lists.prestodb.io' }}
+  LOCAL_IMAGES: ${{ vars.LOCAL_IMAGES || '' }}
+  MULTI_IMAGES: ${{ vars.MULTI_IMAGES || '' }}
 
 jobs:
   release-branch:
@@ -127,6 +129,9 @@ jobs:
           git config --global alias.ls 'log --pretty=format:"%cd %h %ce: %s" --date=short --no-merges'
           git ls -5
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -136,28 +141,60 @@ jobs:
       - name: Release Selected Images
         env:
           RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          DOCKER_ORG: ${{ github.repository_owner }}
+          LOCAL_IMAGES: ${{ env.LOCAL_IMAGES }}
+          MULTI_IMAGES: ${{ env.MULTI_IMAGES }}
         run: |
           IMAGES="${{ github.event.inputs.images }}"
 
           IFS=',' read -ra IMAGE_ARRAY <<< "$IMAGES"
+          IFS=',' read -ra LOCAL_ARRAY <<< "$LOCAL_IMAGES"
+          IFS=',' read -ra MULTI_ARRAY <<< "$MULTI_IMAGES"
+
+          # Function to check if image is in array
+          contains() {
+            local item="$1"
+            shift
+            for elem in "$@"; do
+              [[ "$elem" == "$item" ]] && return 0
+            done
+            return 1
+          }
 
           for IMAGE in "${IMAGE_ARRAY[@]}"; do
-            echo "Building image: $IMAGE"
-            if [ "$IMAGE" = "centos7-oj8" ]; then
+            echo "Processing image: $IMAGE"
+
+            if contains "$IMAGE" "${MULTI_ARRAY[@]}"; then
+              echo "Building multi-arch image: $IMAGE"
+              make "prestodb/$IMAGE@multi" DOCKER_ORG="${DOCKER_ORG}" VERSION="${RELEASE_VERSION}"
+              echo "Multi-arch image built and pushed"
+
+            elif contains "$IMAGE" "${LOCAL_ARRAY[@]}"; then
+              echo "Building local single-arch image: $IMAGE"
               make "prestodb/$IMAGE@local"
+
+              # Tag and push the local image
+              echo "Tagging and pushing image: $IMAGE"
+              docker tag "prestodb/$IMAGE:latest" "${DOCKER_ORG}/$IMAGE:${RELEASE_VERSION}"
+              docker push "${DOCKER_ORG}/$IMAGE:${RELEASE_VERSION}"
+
+              if [ "${{ github.event.inputs.tag_latest }}" = "true" ]; then
+                docker tag "prestodb/$IMAGE:latest" "${DOCKER_ORG}/$IMAGE:latest"
+                docker push "${DOCKER_ORG}/$IMAGE:latest"
+              fi
+
             else
+              echo "Image $IMAGE not found in LOCAL_IMAGES or MULTI_IMAGES variables"
               make "prestodb/$IMAGE"
-            fi
-            docker images
-          done
 
-          for IMAGE in "${IMAGE_ARRAY[@]}"; do
-            echo "Publishing image: $IMAGE"
-            docker tag "prestodb/$IMAGE:latest" "${{ github.repository_owner }}/$IMAGE:$RELEASE_VERSION"
-            docker push "${{ github.repository_owner }}/$IMAGE:$RELEASE_VERSION"
+              docker tag "prestodb/$IMAGE:latest" "${DOCKER_ORG}/$IMAGE:${RELEASE_VERSION}"
+              docker push "${DOCKER_ORG}/$IMAGE:${RELEASE_VERSION}"
 
-            if [ "${{ github.event.inputs.tag_latest }}" = "true" ]; then
-              docker tag "prestodb/$IMAGE:latest" "${{ github.repository_owner }}/$IMAGE:latest"
-              docker push "${{ github.repository_owner }}/$IMAGE:latest"
+              if [ "${{ github.event.inputs.tag_latest }}" = "true" ]; then
+                docker tag "prestodb/$IMAGE:latest" "${DOCKER_ORG}/$IMAGE:latest"
+                docker push "${DOCKER_ORG}/$IMAGE:latest"
+              fi
             fi
+
+            echo "Completed processing: $IMAGE"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,18 +3,6 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      release_type:
-        description: 'Release type'
-        required: true
-        default: 'new_version'
-        type: 'choice'
-        options:
-          - new_version
-          - from_version
-      version:
-        description: 'Version to release(e.g. 12)'
-        required: false
-        type: 'string'
       images:
         description: 'Comma-separated list of images to release (e.g. "centos7-oj8,hdp3.1-hive")'
         required: true
@@ -32,9 +20,29 @@ env:
   MULTI_IMAGES: ${{ vars.MULTI_IMAGES || '' }}
 
 jobs:
+  validate-branch:
+    name: Validate branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          BRANCH_NAME="${{ github.ref }}"
+          echo "Branch: ${BRANCH_NAME}"
+
+          if [[ "${BRANCH_NAME}" == "refs/heads/master" ]] || \
+             [[ "${BRANCH_NAME}" == refs/heads/release-* ]] || \
+             [[ "${BRANCH_NAME}" == refs/heads/patch-* ]]; then
+            echo "✓ Branch is allowed: ${BRANCH_NAME}"
+          else
+            echo "✗ Error: Release workflow can only be run on master, release-*, or patch-* branches"
+            echo "  Current branch: ${BRANCH_NAME}"
+            exit 1
+          fi
+
   release-branch:
     name: Prepare release branch
-    if: ${{ github.event.inputs.release_type == 'new_version' }}
+    needs: [validate-branch]
+    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -42,10 +50,6 @@ jobs:
     outputs:
       release_version: ${{ steps.release_tag.outputs.release_version }}
     steps:
-      - name: Check for master branch
-        if: ${{ github.ref != 'refs/heads/master' }}
-        run: echo "Invalid branch. New release can only be run on the master branch." && exit 1
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -59,38 +63,45 @@ jobs:
           git config --global alias.ls 'log --pretty=format:"%cd %h %ce: %s" --date=short --no-merges'
           git ls -5
 
-      - name: Create release tag
+      - name: Create release branch and tag
         id: release_tag
-        if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           CURRENT_VERSION=$(grep "VERSION :=" Makefile | sed 's/VERSION := //' | sed 's/-SNAPSHOT//')
-          NEW_VERSION=${{ github.event.inputs.version }}
+          NEW_VERSION=${CURRENT_VERSION}
 
-          if [ -z "$NEW_VERSION" ]; then
-            NEW_VERSION=${CURRENT_VERSION}
-          fi
+          # Create release branch
+          git checkout -b release-${NEW_VERSION}
 
+          # Update version in Makefile
           sed -i "s/VERSION := .*/VERSION := ${NEW_VERSION}/" Makefile
           echo "release_version=${NEW_VERSION}" >> $GITHUB_OUTPUT
           git add Makefile
           git commit -m "[release-action] release version ${NEW_VERSION}"
           git ls -5
+
+          # Create release tag
           git tag -a -m "Release version ${NEW_VERSION}" ${NEW_VERSION}
+
+          # Push release branch and tag
+          git push origin release-${NEW_VERSION} --tags
+
+          # Switch back to master for next snapshot version
+          git checkout master
 
       - name: Prepare next snapshot version
         run: |
-          sed -i "s/VERSION := .*/VERSION := $((NEW_VERSION + 1))-SNAPSHOT/" Makefile
+          sed -i "s/VERSION := .*/VERSION := $((${{ steps.release_tag.outputs.release_version }} + 1))-SNAPSHOT/" Makefile
           git add Makefile
           git commit -m "[release-action] prepare for next development iteration"
           git ls -5
-          git push origin master --tags
+          git push origin master
 
   publish-images:
     runs-on: ubuntu-latest
     environment: release
     permissions:
       contents: write
-    needs: [release-branch]
+    needs: [validate-branch, release-branch]
     if: (!failure() && !cancelled())
     steps:
       - name: Validate inputs
@@ -99,28 +110,23 @@ jobs:
             echo "Error: Image names are required."
             exit 1
           fi
-          if [ "${{ github.event.inputs.release_type }}" != "new_version" ]; then
-            if [ -z "${{ github.event.inputs.version }}" ]; then
-              echo "Error: Version is required for from_version release type."
-              exit 1
-            fi
-          fi
-
-      - name: Get checkout branch
-        run: |
-          echo "Get checking out branch"
-          if [ "${{ github.event.inputs.release_type }}" = "new_version" ]; then
-            echo "RELEASE_VERSION=${{ needs.release-branch.outputs.release_version }}" >> $GITHUB_ENV
-          else
-            echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
-          fi
-          echo "RELEASE_VERSION=${{ env.RELEASE_VERSION }}"
 
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           show-progress: false
-          ref: refs/tags/${{ env.RELEASE_VERSION }}
+
+      - name: Determine release version
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            # New release from master
+            echo "RELEASE_VERSION=${{ needs.release-branch.outputs.release_version }}" >> $GITHUB_ENV
+          else
+            # Publishing from release/patch branch - extract version from Makefile
+            RELEASE_VERSION=$(grep "VERSION :=" Makefile | sed 's/VERSION := //' | sed 's/-SNAPSHOT//')
+            echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+          fi
+          echo "Release version: ${{ env.RELEASE_VERSION }}"
 
       - name: Configure Git
         run: |

--- a/prestodb/centos7-oj8/Dockerfile
+++ b/prestodb/centos7-oj8/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM azul/zulu-openjdk-centos:11
+FROM azul/zulu-openjdk-centos:17
 LABEL maintainer="Presto community <https://prestodb.io/community.html>"
 
 COPY ./files /tmp/files

--- a/prestodb/centos7-oj8/Dockerfile
+++ b/prestodb/centos7-oj8/Dockerfile
@@ -28,6 +28,8 @@ RUN \
     yum --enablerepo=extras install -y setuptools epel-release && \
     yum install -y python-pip && \
     pip install --trusted-host pypi.python.org --trusted-host pypi.org --trusted-host files.pythonhosted.org supervisor && \
+    # install python 3
+    yum install -y python3 python3-pip && \
     \
     # install commonly needed packages
     yum install -y \

--- a/prestodb/hdp3.1-hive-kerberized/Dockerfile
+++ b/prestodb/hdp3.1-hive-kerberized/Dockerfile
@@ -10,92 +10,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM prestodb/hdp3.1-hive:unlabelled
+FROM prestodb/hdp3.1-hive:11
 LABEL maintainer="Presto community <https://prestodb.io/community.html>"
 
-# COPY CONFIGURATION
-COPY ./files /tmp/files
-
-# INSTALL KERBEROS
-RUN yum install -y krb5-libs krb5-server krb5-workstation && \
-  # COPY CONFIGURATION FILES
-  cp -a /tmp/files/etc/* /etc/ && \
-  cp -a /tmp/files/var/* /var/ && \
-  chown -R root:hadoop /etc/hadoop /etc/hive && \
-  chown -R root:root /etc/supervisord* /var/kerberos && \
-  # CREATE KERBEROS DATABASE
-  /usr/sbin/kdb5_util create -s -P password && \
-  \
-  # CREATE ANOTHER KERBEROS DATABASE
-  /usr/sbin/kdb5_util create -d /var/kerberos/krb5kdc/principal-other -r OTHERLABS.TERADATA.COM -s -P password && \
-  \
-  # ADD HADOOP PRINCIPALS
-  /usr/sbin/kadmin.local -q "addprinc -randkey hdfs/hadoop-master@LABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -q "addprinc -randkey mapred/hadoop-master@LABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -q "addprinc -randkey yarn/hadoop-master@LABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/hadoop-master@LABS.TERADATA.COM" && \
-  \
-  # CREATE HADOOP KEYTAB FILES
-  /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/hdfs.keytab hdfs/hadoop-master HTTP/hadoop-master" && \
-  /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/mapred.keytab mapred/hadoop-master HTTP/hadoop-master" && \
-  /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/yarn.keytab yarn/hadoop-master HTTP/hadoop-master" && \
-  /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hadoop/conf/HTTP.keytab HTTP/hadoop-master" && \
-  \
-  chown hdfs:hadoop /etc/hadoop/conf/hdfs.keytab && \
-  chown mapred:hadoop /etc/hadoop/conf/mapred.keytab && \
-  chown yarn:hadoop /etc/hadoop/conf/yarn.keytab && \
-  chown hdfs:hadoop /etc/hadoop/conf/HTTP.keytab && \
-  chmod 644 /etc/hadoop/conf/*.keytab && \
-  \
-  # CREATE HIVE PRINCIPAL AND KEYTAB
-  /usr/sbin/kadmin.local -q "addprinc -randkey hive/hadoop-master@LABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/hive/conf/hive.keytab hive/hadoop-master" && \
-  chown hive:hadoop /etc/hive/conf/hive.keytab && \
-  chmod 644 /etc/hive/conf/hive.keytab && \
-  \
-  # CREATE HIVE PRINCIPAL IN THE OTHER REALM
-  /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hive/hadoop-master@OTHERLABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hive/conf/hive-other.keytab hive/hadoop-master" && \
-  chown hive:hadoop /etc/hive/conf/hive-other.keytab && \
-  chmod 644 /etc/hive/conf/hive-other.keytab && \
-  \
-  # CREATE HDFS PRINCIPAL IN OTHER REALM
-  /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -randkey hdfs/hadoop-master@OTHERLABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "xst -norandkey -k /etc/hadoop/conf/hdfs-other.keytab hdfs/hadoop-master" && \
-  chown hdfs:hadoop /etc/hadoop/conf/hdfs-other.keytab && \
-  chmod 644 /etc/hadoop/conf/hdfs-other.keytab && \
-  \
-  # MAKE 'LABS.TERADATA.COM' TRUST 'OTHERLABS.TERADATA.COM'
-  /usr/sbin/kadmin.local -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM@OTHERLABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -r OTHERLABS.TERADATA.COM -d /var/kerberos/krb5kdc/principal-other -q "addprinc -pw 123456 krbtgt/LABS.TERADATA.COM" && \
-  \
-  # CREATE PRESTO PRINCIPAL AND KEYTAB
-  /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-master.docker.cluster@LABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker.docker.cluster@LABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-1.docker.cluster@LABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -q "addprinc -randkey presto-server/presto-worker-2.docker.cluster@LABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -q "addprinc -randkey HTTP/presto-master.docker.cluster@LABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -q "addprinc -randkey presto-client/presto-master.docker.cluster@LABS.TERADATA.COM" && \
-  /usr/sbin/kadmin.local -q "addprinc -randkey hive/presto-master.docker.cluster@LABS.TERADATA.COM" && \
-  mkdir -p /etc/presto/conf && \
-  /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/presto-server.keytab presto-server/presto-master.docker.cluster presto-server/presto-worker.docker.cluster presto-server/presto-worker-1.docker.cluster presto-server/presto-worker-2.docker.cluster" && \
-  /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/presto-server-HTTP.keytab HTTP/presto-master.docker.cluster" && \
-  /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/presto-client.keytab presto-client/presto-master.docker.cluster" && \
-  /usr/sbin/kadmin.local -q "xst -norandkey -k /etc/presto/conf/hive-presto-master.keytab hive/presto-master.docker.cluster" && \
-  chmod 644 /etc/presto/conf/*.keytab && \
-  \
-  # CREATE SSL KEYSTORE
-  keytool -genkeypair \
-      -alias presto \
-      -keyalg RSA \
-      -keystore /etc/presto/conf/keystore.jks \
-      -keypass password \
-      -storepass password \
-      -dname "CN=presto-master, OU=, O=, L=, S=, C=" \
-      -validity 100000 && \
-  chmod 644 /etc/presto/conf/keystore.jks && \
-  # CLEANUP
-  yum -q clean all && rm -rf /var/cache/yum && rm -rf /tmp/* /var/tmp/*
+RUN set -xeu; \
+    rm -f /etc/yum.repos.d/hdp.repo && \
+    yum install -y python3 pip3 && \
+    # cleanup
+    yum -q clean all && rm -rf /var/cache/yum && rm -rf /tmp/* /var/tmp/*
 
 # EXPOSE KERBEROS PORTS
 EXPOSE	88 89 749

--- a/prestodb/hdp3.1-hive-kerberized/Dockerfile
+++ b/prestodb/hdp3.1-hive-kerberized/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM prestodb/hdp3.1-hive:11
+FROM prestodb/hdp3.1-hive-kerberized:11
 LABEL maintainer="Presto community <https://prestodb.io/community.html>"
 
 RUN set -xeu; \

--- a/prestodb/hdp3.1-hive/Dockerfile
+++ b/prestodb/hdp3.1-hive/Dockerfile
@@ -10,65 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM prestodb/centos7-oj8:unlabelled
-LABEL maintainer="Presto community <https://prestodb.io/community.html>"
+FROM prestodb/hdp3.1-hive:11
 
-# copy configuration files
-COPY ./files /tmp/files
-
-# install HDP repo
 RUN set -xeu; \
-      echo '[HDP]' > /etc/yum.repos.d/hdp.repo && \
-      echo 'name=HDP' >> /etc/yum.repos.d/hdp.repo && \
-      echo 'baseurl=https://hdpweb.o.onslip.net/p/HDP/3.x/3.1.0.0/centos7' >> /etc/yum.repos.d/hdp.repo && \
-      echo 'enabled=1' >> /etc/yum.repos.d/hdp.repo && \
-      echo 'gpgcheck=0' >> /etc/yum.repos.d/hdp.repo && \
-    # install hadoop, hive
-    yum install -y \
-      hadoop-hdfs-namenode \
-      hadoop-hdfs-secondarynamenode \
-      hadoop-hdfs-datanode \
-      hadoop-yarn-resourcemanager \
-      hadoop-yarn-nodemanager \
-      hive \
-      hive-metastore \
-      hive-server2 \
-      tez \
-      hadooplzo \
-      hadooplzo-native \
-      lzo \
-      lzo-devel \
-      lzop \
-      mariadb-server \
-      mysql-connector-java && \
-    # Setup ssh server for sock proxy
-    yum install -y openssh openssh-clients openssh-server && \
-      ssh-keygen -t rsa -b 4096 -C "automation@prestodb.io" -N "" -f /root/.ssh/id_rsa && \
-      ssh-keygen -t rsa -b 4096 -N "" -f /etc/ssh/ssh_host_rsa_key && \
-      cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
-      passwd --unlock root && \
-    # mysql connector
-    ln -s /usr/share/java/mysql-connector-java.jar /usr/hdp/current/hive-metastore/lib/mysql-connector-java.jar && \
-    # delete original configuration
-    rm -r /etc/hadoop/conf/* && rm -r /etc/hive/conf/* && \
-    # copy configurations
-    cp -a /tmp/files/root/* /root/ && \
-      cp -a /tmp/files/etc/* /etc/ && \
-      chown -R root:hadoop /etc/hadoop /etc/hive /etc/tez && \
-      chown -R root:root /etc/supervisord* /var/kerberos && \
-      chown -R root:root /root && \
-      chmod 0700 /root /root/.ssh && \
-    # setup hadoop and hive
-    /root/setup.sh && \
-    set -xeu; \
-    echo "supervisorctl restart all" >> ~root/.bash_history; \
-    for user in root hive hdfs; do \
-        sudo -u "${user}" bash -c ' echo "netstat -ltnp" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "beeline -n hive" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' echo "hdfs dfs -ls -R /user/hive/warehouse" >> ~/.bash_history '; \
-        sudo -u "${user}" bash -c ' mkdir -p ~/.beeline '; \
-        sudo -u "${user}" bash -c ' echo "SELECT current_user();" >> ~/.beeline/history '; \
-    done && \
+    rm -f /etc/yum.repos.d/hdp.repo && \
+    yum install -y python3 pip3 && \
     # cleanup
     yum -q clean all && rm -rf /var/cache/yum && rm -rf /tmp/* /var/tmp/*
 

--- a/prestodb/hdp3.1-hive/Dockerfile
+++ b/prestodb/hdp3.1-hive/Dockerfile
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 FROM prestodb/hdp3.1-hive:11
+LABEL maintainer="Presto community <https://prestodb.io/community.html>"
 
 RUN set -xeu; \
     rm -f /etc/yum.repos.d/hdp.repo && \


### PR DESCRIPTION
# Release Workflow Improvements

This PR refactors the GitHub Actions release workflow to simplify the release process and fix critical bugs.

## Changes

### 1. Fixed Version Increment Bug 🐛

**Problem:** When releasing version 11, the next snapshot version became `1-SNAPSHOT` instead of `12-SNAPSHOT`

**Fix:** Correctly reference the release version output for arithmetic increment
```bash
# Before: $((NEW_VERSION + 1))
# After:  $((${{ steps.release_tag.outputs.release_version }} + 1))
```

### 2. Simplified Release Process ✨

**Removed manual input parameters:**
- ❌ `release_type` (new_version/from_version)
- ❌ `version` (manual version number)

**New branch-based approach:**
- Run on `master` → Creates new release automatically
- Run on `release-*` or `patch-*` → Publishes that release

### 3. Added Branch Validation 🛡️

New validation job ensures workflow only runs on:
- `master` - for creating new releases
- `release-*` - for publishing releases
- `patch-*` - for publishing patches

Fails fast with clear error message on invalid branches.

### 4. Release Branch Creation 🌿

When running on master, the workflow now:
1. Creates `release-{VERSION}` branch (e.g., `release-11`)
2. Creates `{VERSION}` tag on that branch
3. Pushes both branch and tag
4. Updates master to next SNAPSHOT version (e.g., `12-SNAPSHOT`)

### 5. Simplified Checkout Logic 🔄

Removed redundant tag checkout - now uses single checkout of the selected branch for clearer flow.

### 6. Upgraded centos7-oj8 to JDK 17 ☕

Updated base image from `azul/zulu-openjdk-centos:11` to `azul/zulu-openjdk-centos:17` for better performance and long-term support.

### 7. Added Python 3 Support 🐍

Added Python 3 and pip3 to centos7-oj8 image, providing both Python 2 and Python 3 support for modern applications.

### 8. Multi-Architecture Build Support 🏗️

Added Docker Buildx support for building multi-architecture images (linux/amd64 and linux/arm64):
- New Makefile target `@multi` for multi-arch builds
- Configurable via `LOCAL_IMAGES` and `MULTI_IMAGES` repository variables
- Automatic platform detection and building

## Usage

### Creating a New Release
1. Go to Actions → Release workflow
2. Select branch: **master**
3. Enter image names
4. Run workflow

Result: Creates release branch, tag, publishes images, and prepares master for next version.

### Publishing Existing Release
1. Go to Actions → Release workflow
2. Select branch: **release-11** (or patch-11)
3. Enter image names
4. Run workflow

Result: Publishes images from that release branch.

## Benefits

- ✅ No more manual version entry
- ✅ Automatic version increments work correctly
- ✅ Release branches provide clear history
- ✅ Safer with branch validation
- ✅ Can republish any release from its branch
